### PR TITLE
Handle root's pom.xml not matching plugin name

### DIFF
--- a/reports.js
+++ b/reports.js
@@ -108,7 +108,8 @@ async function getPulls( ) {
       if (pluginName) {
         projectToPull[pluginName] = url;
       }
-    } else if (url) {
+    }
+    if (url) {
       const pluginName = url.replace(/^.*\/(.*)-plugin\/.*$/, '$1');
       projectToPull[pluginName] = url;
     }


### PR DESCRIPTION
Since projectToPull obj is just for checking if theres a PR, then populate it any way we can