### PR TITLE
Use update-center.actual.json as primary source

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -1,34 +1,6 @@
 /* eslint-env node */
 const {GraphQLClient} = require('graphql-request');
 
-const getAllTopicsQuery = `
-query getAllTopicsQuery($login: String!, $after: String) {
-  organization(login: $login) {
-    repositories(first: 100, after: $after) {
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          isArchived
-          url
-          repositoryTopics(first: 100) {
-            edges {
-              node {
-                topic {
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-`;
-
 const getPullRequestsQuery = `
 query getPullRequests($login: String!) {
   organization(login: $login) {
@@ -43,13 +15,6 @@ query getPullRequests($login: String!) {
                   content {
                     ... on PullRequest {
                       url
-                      baseRepository {
-                        object(expression: "master:pom.xml") {
-                          ... on Blob {
-                            text
-                          }
-                        }
-                      }
                     }
                   }
                 }
@@ -91,22 +56,6 @@ async function getPullRequests() {
   );
 }
 
-/**
- * Gets labels for all repos (paginated)
- *  @param {string} after pagination
- * @return {object}
- */
-async function getAllTopics(after) {
-  return getGithubClient().request(
-      getAllTopicsQuery,
-      {
-        login: 'jenkinsci',
-        after: after,
-      },
-  );
-}
-
 module.exports = {
   getPullRequests,
-  getAllTopics,
 };

--- a/reports.js
+++ b/reports.js
@@ -10,7 +10,7 @@ const docsUrl = 'http://updates.jenkins.io/plugin-documentation-urls.json';
  * @return {array} of objects representing table rows
  */
 async function pluginsReport() {
-  const updateCenterUrl = 'http://updates.jenkins.io/current/update-center.actual.json';
+  const updateCenterUrl = 'https://updates.jenkins.io/current/update-center.actual.json';
 
 
   const documentation = await getContent(docsUrl, 'json');

--- a/views/progress.ejs
+++ b/views/progress.ejs
@@ -5,7 +5,7 @@
     <div class="container">
       <%- include('navigation'); %>
       <h1>Plugin Migration Progress</h1>
-      <p>Todo: <%= statuses.todo %>, PR: <%= statuses.pr %>, Done: <%= statuses.ok + statuses.deprecated %>, Total: <%= statuses.total %></p>
+      <p>Todo: <%= statuses.todo %>, PR open: <%= statuses["pr open"] %>, PR merged: <%= statuses["pr merged"] %>, Done: <%= statuses.ok + statuses.deprecated %>, Total: <%= statuses.total %></p>
 
       <table class="table table-bordered table-hover" data-sortable="true" data-sort-name="installs" data-sort-order="desc"  data-toggle="table">
         <thead class="thead-dark">
@@ -31,7 +31,12 @@
         </tr>
       <% }); %>
       </table>
+      <% if (recent.length) { %>
+      <h3 class="mt-3">Recently merged</h3>
+      <%= recent.join(", ") %>
+      <% } %>
     </div>
+
 
     <link rel="stylesheet" href="/vendor/bootstrap-table.min.css" />
 


### PR DESCRIPTION
This way we should get more accurate info about deprecated plugins (if label override is used in UC repo and no label is set on plugin repo) and we should be able to avoid some XML parsing.

If a documentation PR is open in repo shared by multiple plugins it's counted for all of them.

List of recently merged PRs added below the table for easier management of https://github.com/orgs/jenkinsci/projects/3 .